### PR TITLE
Add note about broken classDef in some versions

### DIFF
--- a/content/flowchart.md
+++ b/content/flowchart.md
@@ -262,6 +262,8 @@ graph LR
 
 #### Classes
 
+> **Success** The `classDef` functionality is available through version 7.0.14 and from version 8.0.0-alpha.9. It does not work in versions 7.0.15 through 8.0.0-alpha.8
+
 More convenient then defining the style every time is to define a class of styles and attach this class to the nodes that
 should have a different look.
 


### PR DESCRIPTION
The main reason for adding this is that GitLab uses version 7.1.0 which does not properly handle `classDef` declarations.