### PR TITLE
update flowchart.md, move caption to above diagram

### DIFF
--- a/content/flowchart.md
+++ b/content/flowchart.md
@@ -13,6 +13,11 @@ graph TD
 
 This declares a graph oriented from left to right.
 
+```mermaid
+graph LR
+    Start --> Stop
+```
+
 Possible directions are:
 
 * TB - top bottom
@@ -21,11 +26,6 @@ Possible directions are:
 * LR - left right
 
 * TD - same as TB
-
-```mermaid
-graph LR
-    Start --> Stop
-```
 
 ## Nodes & shapes
 


### PR DESCRIPTION
The listing of all directions is right in the middle of a diagram caption and a diagram, it is confusing this way.

This just moved the listing below both example diagrams and their captions.

### Before:
<kbd><img width="557" alt="screen shot 2018-07-11 at 11 40 52 am" src="https://user-images.githubusercontent.com/5262154/42583778-b0d15320-84ff-11e8-9238-0169e2cc0e55.png"></kbd>


### After:
<kbd><img width="604" alt="screen shot 2018-07-11 at 11 41 50 am" src="https://user-images.githubusercontent.com/5262154/42583787-b4aa14dc-84ff-11e8-9386-296e9ecb9752.png"></kbd>
