### PR TITLE
Show arrows instead of a straight line in sequence diagram

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -32,14 +32,14 @@ graph TD;
 sequenceDiagram
     participant Alice
     participant Bob
-    Alice->John: Hello John, how are you?
+    Alice->>John: Hello John, how are you?
     loop Healthcheck
-        John->John: Fight against hypochondria
+        John->>John: Fight against hypochondria
     end
     Note right of John: Rational thoughts <br/>prevail...
-    John-->Alice: Great!
-    John->Bob: How about you?
-    Bob-->John: Jolly good!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
 ```
 
 


### PR DESCRIPTION
Only after reading the docs I saw that you can have a direction. Initially when reading the front page, I could only be a straight line.