### PR TITLE
Fixed typo for 'description' in gantt.md

### DIFF
--- a/content/gantt.md
+++ b/content/gantt.md
@@ -225,7 +225,7 @@ mermaid.ganttConfig = {
 
 ### Possible configration params:
 
-Param | Descriotion | Default value
+Param | Description | Default value
 --- | --- | ---
 mirrorActor|Turns on/off the rendering of actors below the diagram as well as above it|false
 bottomMarginAdj|Adjusts how far down the graph ended. Wide borders styles with css could generate unwantewd clipping which is why this config param exists.|1


### PR DESCRIPTION
Migrating the typo fix from https://github.com/mermaidjs/mermaidjs.github.io/pull/3 to here. There are no other instances of `Descriotion ` found in this repo.

A similar PR where this issue was addressed: #22 