### PR TITLE
Fix link to mermaid API documentation

### DIFF
--- a/content/usage.md
+++ b/content/usage.md
@@ -274,7 +274,7 @@ setting the options in mermaid.
 4. Instantiation of the configuration using the **mermaid.init** call
 
 The list above has two ways to many of doing this. Three are deprecated and will eventually be removed. The list of
-configuration objects are described [in the mermaidAPI documentation](mermaidAPI.html).
+configuration objects are described [in the mermaidAPI documentation](mermaidAPI.md).
 
 
 ## Using the `mermaidAPI.initialize`/`mermaid.initialize` call


### PR DESCRIPTION
This PR fixes a broken link to the mermaidAPI documentation